### PR TITLE
Replace erlang:now for os:timestamp

### DIFF
--- a/examples/performance_logger.erl
+++ b/examples/performance_logger.erl
@@ -122,7 +122,7 @@ handle_cast(ping, State = #state{data_spec = DataSpec}) ->
 handle_cast({start_recording, DataSpec}, State) ->
     ets:delete_all_objects(?PFL_ETS_NAME),
     {ok, TRef} = timer:apply_interval(?SAMPLING_TIME, ?MODULE, tick, []),
-    {noreply, State#state{start_time = erlang:now(),
+    {noreply, State#state{start_time = os:timestamp(),
                           %% we add two default counters, that measure CPU load and memory usage.
                           data_spec = [{fun cpu_load/0, "CPULoad", identity},
                                        {fun memory_use/0, "MemoryUse", identity} | DataSpec],
@@ -183,7 +183,7 @@ calculate_sample(Counters) ->
               Counters).
 
 compute_time_offset(#state{start_time = StartTime}) ->
-    timer:now_diff(erlang:now(), StartTime) * ?TIME_COMPUTATION_SCALE.
+    timer:now_diff(os:timestamp(), StartTime) * ?TIME_COMPUTATION_SCALE.
 
 %%
 save_header(DataSpec, File) ->

--- a/src/jobs_lib.erl
+++ b/src/jobs_lib.erl
@@ -22,7 +22,7 @@
 
 timestamp() ->
     %% Invented epoc is {1258,0,0}, or 2009-11-12, 4:26:40
-    {MS,S,US} = erlang:now(),
+    {MS,S,US} = os:timestamp(),
     (MS-1258)*1000000000 + S*1000 + US div 1000.
 
 timestamp_to_datetime(TS) ->

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -1648,7 +1648,7 @@ next_time_(TS, #queue{latest_dispatch = TS1,
 %% Microsecond timestamp; never wraps
 timestamp() ->
     %% Invented epoc is {1258,0,0}, or 2009-11-12, 4:26:40
-    {MS,S,US} = erlang:now(),
+    {MS,S,US} = os:timestamp(),
     (MS-1258)*1000000000000 + S*1000000 + US.
 
 timestamp_to_datetime(TS) ->

--- a/test/jobs_server_tests.erl
+++ b/test/jobs_server_tests.erl
@@ -167,9 +167,9 @@ stop_server() ->
     application:stop(jobs).
 
 tc(F) ->
-    T1 = erlang:now(),
+    T1 = os:timestamp(),
     R = (catch F()),
-    T2 = erlang:now(),
+    T2 = os:timestamp(),
     {timer:now_diff(T2,T1), R}.
 
 run_jobs(Q,N) ->


### PR DESCRIPTION
Compile with Erlang 18 we get some warnings like this one:

```
src/jobs_lib.erl:25: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
```

The tests are passing just using `os:timestamp()` but I don't know if jobs uses the fact that `erlang:now()` is monotonic.

I was just going to create an issue but there's no way to create one right now.
