### PR TITLE
fix queue resumption after modifier reduces counter to 0

### DIFF
--- a/src/jobs_sampler.erl
+++ b/src/jobs_sampler.erl
@@ -318,8 +318,9 @@ calc_modifiers(Samplers, #state{modifiers = Modifiers0} = S) ->
 			  sampler_error(Err, Sx),
 			  {Sx, {Acc,Flg}}
 		  end
-	  end, {Modifiers0, false}, Samplers),
-    S#state{samplers = Samplers1, modifiers = Modifiers1, modified = IsModified}.
+	  end, {orddict:new(), false}, Samplers),
+    FinalMods = orddict:merge(fun(_,V,_) -> V end,Modifiers1,Modifiers0),
+    S#state{samplers = Samplers1, modifiers = FinalMods, modified = IsModified}.
 
 
 merge_modifiers(New, Modifiers) ->

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -690,11 +690,20 @@ i_handle_call({set_modifiers, Modifiers}, _, #st{queues     = Qs,
 						 group_rates = GRs,
 						 counters    = Cs} = S) ->
     GRs1 = [apply_modifiers(Modifiers, G) || G <- GRs],
-    Cs1  = [apply_modifiers(Modifiers, C) || C <- Cs],
     Qs1  = [apply_modifiers(Modifiers, Q) || Q <- Qs],
-    {reply, ok, S#st{queues = Qs1,
-		     group_rates = GRs1,
-		     counters = Cs1}};
+    {Revisit,Cs1}  =
+        lists:foldl(fun(C,{RevAcc,CAcc}) ->
+                            C1 = apply_modifiers(Modifiers, C),
+                            case get_rate(C) < get_rate(C1) of
+                                true -> {union(C1#cr.queues,RevAcc),[C1|CAcc]};
+                                _ -> {RevAcc,[C1|CAcc]}
+                            end
+                    end,{[],[]},Cs),
+    S1 = revisit_queues(Revisit,
+                        S#st{queues = Qs1,
+                             group_rates = GRs1,
+                             counters = lists:reverse(Cs1)}),
+    {reply, ok, S1};
 i_handle_call({add_queue, Name, Options}, _, #st{queues = Qs} = S) ->
     false = get_queue(Name, Qs),
     NewQueues = init_queues([{Name, Options}], S),


### PR DESCRIPTION
I was noticing an issue where a queue (used for periodic background processing) with a counter that is modified by the cpu regulator would 'freeze' after system cpu went high.  My background processes would just stop until jobs was restarted.  It turns out that the modifiers values would never reduces after going up, and that if all of my background processors were busy waiting on jobs:ask, nothing would cause jobs_server to allow() them. so I:

 * change merging of modifiers in jobs_sampler:calc_modifiers so that
    a new modifier that is lower can override an old higher modifier
 * when modifiers are set in jobs_server, check to see if any of the new
    modified counter values are higher than before; if so, revisit queues