### PR TITLE
update jobs_server for signature of Queue:timedout/1

### DIFF
--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -169,8 +169,8 @@ info(oldest_job, #queue{oldest_job = OJ}) -> OJ;
 info(length    , #queue{st = #st{table = Tab}}) ->
     ets:info(Tab, size).
 
--spec timedout(#queue{}) -> [] | {[entry()], #queue{}}.
-%% @spec timedout(#queue{}) -> [] | {[Entry], #queue{}}
+-spec timedout(#queue{}) -> {[entry()], #queue{}}.
+%% @spec timedout(#queue{}) -> {[Entry], #queue{}}
 %% @doc Return all entries that have been in the queue longer than MaxTime.
 %%
 %% NOTE: This is an inspection function; it doesn't remove the job entries.
@@ -180,7 +180,7 @@ timedout(#queue{max_time = undefined} = Q) -> {[], Q};
 timedout(#queue{max_time = TO} = Q) ->
     timedout(TO, Q).
 
-timedout(_ , #queue{oldest_job = undefined}) -> [];
+timedout(_ , #queue{oldest_job = undefined} = Q) -> {[], Q};
 timedout(TO, #queue{st = #st{table = Tab}} = Q) ->
     Now = timestamp(),
     Objs = find_expired(Tab, Now, TO),

--- a/src/jobs_queue_list.erl
+++ b/src/jobs_queue_list.erl
@@ -116,11 +116,11 @@ info(length    , #queue{st = L}) ->
 %%
 %% Return all entries that have been in the queue longer than MaxTime.
 %%
-timedout(#queue{max_time = undefined}) -> [];
+timedout(#queue{max_time = undefined} = Q) -> {[],Q};
 timedout(#queue{max_time = TO} = Q) ->
     timedout(TO, Q).
 
-timedout(_ , #queue{oldest_job = undefined}) -> [];
+timedout(_ , #queue{oldest_job = undefined} = Q) -> {[],Q};
 timedout(TO, #queue{st = L} = Q) ->
     Now = jobs_server:timestamp(),
     {Left, Timedout} = lists:splitwith(fun({TS,_}) ->

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -1017,7 +1017,7 @@ check_timedout(#queue{max_time   = MaxT,
 		      oldest_job = Oldest} = Q, TS) ->
     if (TS - Oldest) > MaxT * 1000 ->
 	    case q_timedout(Q) of
-		[] -> Q;
+		{[],Q1} -> Q1;
 		{OldJobs, Q1} ->
 		    [timeout(J) || J <- OldJobs],
 		    Q1
@@ -1489,9 +1489,9 @@ queue_job(TS, From, #queue{max_size = MaxSz} = Q, S) ->
     CurSz = q_info(length, Q),
     if CurSz >= MaxSz ->
             case q_timedout(Q) of
-                [] ->
+                {[],Q1} ->
                     reject(From),
-                    {Q, S};
+                    {Q1, S};
                 {OldJobs, Q1} ->
                     [timeout(J) || J <- OldJobs],
                     %% update_queue(q_in(TS, From, Q1), S)
@@ -1586,7 +1586,7 @@ init_producer(Type, _Opts, Q) ->
                              state = ModS}}.
 
 q_all     (#queue{mod = Mod} = Q)     -> Mod:all     (Q).
-q_timedout(#queue{mod = Mod} = Q)     -> Mod:timedout(Q).
+q_timedout(#queue{mod = Mod} = Q)     -> case Mod:timedout(Q) of [] -> {[],Q}; X -> X end.
 q_delete  (#queue{mod = undefined})   -> ok;
 q_delete  (#queue{mod = Mod} = Q)     -> Mod:delete  (Q).
 %%


### PR DESCRIPTION
  jobs_queue:timedout returns [] | {[entry()],#queue{}}, and jobs_server
  was assuming [] would be returned if no entries found.  q_timedout/1
  now promotes [] to {[],Q}; call locations modded to match.

I felt this was the best fix, since other people's implementations of jobs_queue behaviour might have this same return pattern, or might return [].