### PR TITLE
compatibility with erlang 18

### DIFF
--- a/src/jobs_lib.erl
+++ b/src/jobs_lib.erl
@@ -15,14 +15,18 @@
 %%==============================================================================
 
 -module(jobs_lib).
+%% We don't want warnings about the use of erlang:now/0 in
+%% this module.
+-compile(nowarn_deprecated_function).
 
 -export([timestamp/0,
-         timestamp_to_datetime/1]).
+         timestamp_to_datetime/1,
+         time_compat/0]).
 
 
 timestamp() ->
     %% Invented epoc is {1258,0,0}, or 2009-11-12, 4:26:40
-    {MS,S,US} = erlang:now(),
+    {MS,S,US} = time_compat(),
     (MS-1258)*1000000000 + S*1000 + US div 1000.
 
 timestamp_to_datetime(TS) ->
@@ -33,3 +37,10 @@ timestamp_to_datetime(TS) ->
     MS = TS rem 1000,
     %% return {Datetime, Milliseconds}
     {calendar:now_to_datetime({1258,S,0}), MS}.
+
+%% create the jobs_time_compat module for efficiency
+time_compat() ->
+    case erlang:is_builtin(erlang,timestamp,0) of
+        true -> erlang:timestamp();
+        false -> erlang:now()
+    end.

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -1657,7 +1657,7 @@ next_time_(TS, #queue{latest_dispatch = TS1,
 %% Microsecond timestamp; never wraps
 timestamp() ->
     %% Invented epoc is {1258,0,0}, or 2009-11-12, 4:26:40
-    {MS,S,US} = erlang:now(),
+    {MS,S,US} = jobs_lib:time_compat(),
     (MS-1258)*1000000000000 + S*1000000 + US.
 
 timestamp_to_datetime(TS) ->

--- a/test/jobs_server_tests.erl
+++ b/test/jobs_server_tests.erl
@@ -167,9 +167,9 @@ stop_server() ->
     application:stop(jobs).
 
 tc(F) ->
-    T1 = erlang:now(),
+    T1 = jobs_lib:time_compat(),
     R = (catch F()),
-    T2 = erlang:now(),
+    T2 = jobs_lib:time_compat(),
     {timer:now_diff(T2,T1), R}.
 
 run_jobs(Q,N) ->


### PR DESCRIPTION
add compatibility with erlang 18 and sup. use  `erlang:timestamp()` instead of `erlang:now()`