### PR TITLE
Fix the expiry calculation of requests

### DIFF
--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -259,4 +259,4 @@ empty(#queue{st = #st{table = T}} = Q) ->
 
 is_expired(TS, Now, TO) ->
     MS = Now - TS,
-    MS > TO.
+    MS > TO * 1000.


### PR DESCRIPTION
Convert the configured max_time value to microseconds for proper calculation.