### PR TITLE
Dialyzer spec fixes

### DIFF
--- a/include/jobs.hrl
+++ b/include/jobs.hrl
@@ -26,8 +26,6 @@
 -export_type([counter/0, reg_obj/0]).
 
 -type job_class() :: any().
--opaque counter() :: {any(), any()}.
--opaque reg_obj() :: [counter()].
 
 -type mod_args() :: {atom(), list()}.
 -type mod_fun() :: {atom(), atom()}.
@@ -126,6 +124,9 @@
      % active_modifiers = []  :: [{atom(),integer()}],
          % preset_limit = 5,
          shared = false}).
+
+-opaque counter() :: {#cr{}, non_neg_integer()}.
+-opaque reg_obj() :: {reference(), [{info, any()} | {counters, [counter()]}]}.
 
 -record(grp, {name,
           rate = #rate{},

--- a/src/jobs_sampler.erl
+++ b/src/jobs_sampler.erl
@@ -32,7 +32,6 @@
 	 calc/3]).
 
 -export([init/1,
-	 behaviour_info/1,
 	 handle_call/3,
 	 handle_cast/2,
 	 handle_info/2,
@@ -60,12 +59,11 @@
 		remote_modifiers = []}).
 
 
-behaviour_info(callbacks) ->
-    [{init, 2},
-     {sample, 2},
-     {handle_msg, 3},
-     {calc, 2}].
-
+-callback init(Name :: any(), Opts :: proplists:proplist()) -> {ok, State :: any()}.
+-callback sample(Timestamp :: integer(), State :: any()) -> {Result :: any(), State :: any()}.
+-callback handle_msg(Msg :: any(), Timestamp :: integer(), State :: any())
+    -> {ignore, State :: any()} | {log, Sample :: any(), State :: any()}.
+-callback calc(History :: any(), State :: any()) -> {Modifiers :: q_modifiers(), State :: any()}.
 
 trigger_sample() ->
     gen_server:cast(?MODULE, sample).

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -89,7 +89,7 @@ ask() ->
     ask(default).
 
 
--spec ask(job_class()) -> {ok, counter()} | {error, rejected | timeout}.
+-spec ask(job_class()) -> {ok, reg_obj()} | {error, rejected | timeout}.
 %%
 ask(Type) ->
     call(?SERVER, {ask, Type}, infinity).
@@ -122,7 +122,7 @@ run(Type, Fun) when is_function(Fun, 1) ->
             erlang:error(Reason)
     end.
 
--spec done(counter()) -> ok.
+-spec done(reg_obj()) -> ok.
 %%
 done({undefined, _}) ->
     %% no monitoring on this job (e.g. from a {action, approve} queue)

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -234,8 +234,8 @@ call(Server, Req, Timeout) ->
 %% approve(From) ->
 %%     approve(From, []).
 
-approve(From, Counter) ->
-    gen_server:reply(From, {ok, Counter}).
+approve(From, Counters) ->
+    gen_server:reply(From, {ok, Counters}).
 
 
 reject(From) ->

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -89,7 +89,7 @@ ask() ->
     ask(default).
 
 
--spec ask(job_class()) -> {ok, reg_obj()} | {error, rejected | timeout}.
+-spec ask(job_class()) -> {ok, counter()} | {error, rejected | timeout}.
 %%
 ask(Type) ->
     call(?SERVER, {ask, Type}, infinity).
@@ -122,7 +122,7 @@ run(Type, Fun) when is_function(Fun, 1) ->
             erlang:error(Reason)
     end.
 
--spec done(reg_obj()) -> ok.
+-spec done(counter()) -> ok.
 %%
 done({undefined, _}) ->
     %% no monitoring on this job (e.g. from a {action, approve} queue)
@@ -145,12 +145,12 @@ dequeue(Type, N) when N==infinity; is_integer(N), N > 0 ->
     call(?SERVER, {dequeue, Type, N}, infinity).
 
 
--spec add_queue(queue_name(), [option()]) -> ok.
+-spec add_queue(queue_name(), q_opts()) -> ok.
 %%
 add_queue(Name, Options) ->
     call(?SERVER, {add_queue, Name, Options}).
 
--spec modify_queue(queue_name(), [option()]) -> ok.
+-spec modify_queue(queue_name(), q_opts()) -> ok.
 %%
 modify_queue(Name, Options) ->
     call(?SERVER, {modify_queue, Name, Options}).
@@ -234,8 +234,8 @@ call(Server, Req, Timeout) ->
 %% approve(From) ->
 %%     approve(From, []).
 
-approve(From, Counters) ->
-    gen_server:reply(From, {ok, Counters}).
+approve(From, Counter) ->
+    gen_server:reply(From, {ok, Counter}).
 
 
 reject(From) ->
@@ -252,7 +252,8 @@ timeout({_, {Pid,Ref} = From}) when is_pid(Pid), is_reference(Ref) ->
 start_link() ->
     start_link(options()).
 
--spec start_link([option()]) -> {ok, pid()}.
+-type ctx_options() :: [{_Ctxt :: env | opts, _App:: user | atom(), [option()]}].
+-spec start_link(ctx_options()) -> {ok, pid()}.
 %%
 start_link(Opts0) when is_list(Opts0) ->
     Opts = expand_opts(sort_groups(group_opts(Opts0))),
@@ -260,7 +261,7 @@ start_link(Opts0) when is_list(Opts0) ->
 
 %% Server-side callbacks and helpers
 
--spec options() -> [{_Ctxt :: env | opts, _App:: user | atom(), [option()]}].
+-spec options() -> ctx_options().
 options() ->
     JobsOpts = {env, jobs, application:get_all_env(jobs)},
     Other = try [{env, A, Os} || {A, Os} <- setup:find_env_vars(jobs)]
@@ -291,7 +292,7 @@ sort_groups(Gs) ->
     [Jobs] = [J || {env, jobs, _} = J <- Gs],
     User ++ [Jobs | Gs -- [Jobs | User]].
 
--spec expand_opts([option()]) -> [option()].
+-spec expand_opts(ctx_options()) -> ctx_options().
 %%
 expand_opts([{Ctxt, A, Opts}|T]) ->
     Exp = try expand_opts_(Opts)
@@ -1203,7 +1204,7 @@ check_cr(Val, I, Max) ->
     end.
 
 -spec dispatch_N(integer() | infinity, [any()], integer(), #queue{}, #st{}) ->
-			{list(), #queue{}}.
+			{integer(), list(), #queue{}}.
 %%
 dispatch_N(N, Counters, TS, #queue{name = QName,
 				    approved = Approved0,


### PR DESCRIPTION
I fleshed out the types and fixed various spec issues, reducing the internal dialyzer warnings to just two about: `Callback info about the jobs_sampler behaviour is not available`

I also tidied up mixed space/tab use in the hrl file. No code changes were made and tests still pass.

This should resolve #22