### PR TITLE
Fix busy-loop problem when combining rate & counter reg

### DIFF
--- a/include/jobs.hrl
+++ b/include/jobs.hrl
@@ -167,6 +167,8 @@
         oldest_job           :: integer() | undefined,
         timer,
         check_counter = 0    :: integer(),
+        empty = false        :: boolean(),
+        depleted = false     :: boolean(),
         waiters = []         :: [{pid(), reference()}],
         stateful,
         st

--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -1573,12 +1573,12 @@ queue_job(TS, From, #queue{max_size = MaxSz} = Q, S) ->
     case {CurSz >= MaxSz, IsOverload} of
         {true, true} ->
             reject(From),
-            {Q, S};
+            {Q, #q_check{}, S};
         {true, false} ->
             case q_timedout(Q) of
                 {[],Q1} ->
                     reject(From),
-                    {Q1, S};
+                    {Q1, #q_check{}, S};
                 {OldJobs, Q1} ->
                     [timeout(J) || J <- OldJobs],
                     job_queued(q_in(TS, From, Q1), CurSz, IsOverload, TS, S)


### PR DESCRIPTION
- Avoid multiple timer restarts
- Don't revisit if timer running
- TODO: if counter reg at zero, no need to set timer