### PR TITLE
Record dynamic changes and replay at restart if `auto_restore=true`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: erlang
 sudo: false
 otp_release:
+- 21.1
 - 21.0
 - 20.3
-- 19.3
-- 18.3
+- 20.2
+- 20.1
 script:
 - rebar3 eunit
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ otp_release:
 - 20.3
 - 20.2
 - 20.1
+- 19.3
+- 18.3
 script:
 - rebar3 eunit
 notifications:

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -49,6 +49,16 @@ Specifically, jobs provides three features:
   which we execute jobs. When the health problem clears, we remove the
   dampener and run at full speed again.
 
+Error recovery
+--------------
+
+The Jobs server is designed to not crash. However, in the unlikely event
+that it should occur (and it has!) Jobs does not automatically restore changes
+that have been effected through the API. This can be enabled, setting the
+Jobs environment variable `auto_restore' to `true', or calling the function
+`jobs_server:auto_restore(true)'. This will tell the jobs_server to remember
+every configuration change and replay them, in order, after a process restart.
+
 Examples
 --------
 

--- a/test/jobs_server_tests.erl
+++ b/test/jobs_server_tests.erl
@@ -63,9 +63,9 @@ restart_jobs_server() ->
     await_jobs_server(1000).
 
 test_rate(Q, R) ->
-            T0 = erlang:system_time(millisecond),
+            T0 = jobs_lib:timestamp(),
             Times = [jobs:run(Q, fun() ->
-                                          erlang:system_time(millisecond)
+                                         jobs_lib:timestamp()
                                   end) || _ <- lists:seq(1,10)],
     TimeLimit = 1000 * 10 * (1/R), % in milliseconds
     Actual = (lists:last(Times) - T0),

--- a/test/jobs_server_tests.erl
+++ b/test/jobs_server_tests.erl
@@ -25,11 +25,129 @@ rate_test_() ->
        , {[{rate,5},{count,3}],
           fun(_,_) -> [fun() -> par_run(5,5,1) end] end}
        , {{timeout,500}, fun(_,_) -> [fun() ->
-					      ?debugVal(timeout_test(500))
-				      end] end}
+                                              ?debugVal(timeout_test(500))
+                                      end] end}
       ]}.
 
 
+config_test_() ->
+    {foreachx,
+     fun(Conf) -> start_server_w_config(Conf) end,
+     fun(_, _) -> stop_server() end,
+     [ {#{ restore => {true, preset}
+         , preset => [{queue,q}]
+         , dynamic => [{queue,q1}]}, fun config_test_f/2}
+     , {#{ restore => {false, preset}
+         , preset => [{queue,q}]
+         , dynamic => [{queue,q1}] }, fun config_test_f/2}
+     , {#{ restore => {true, preset}
+         , preset => []
+         , dynamic => [{queue,q1,[{standard_rate,100}]}] }, fun rate_recovers/2}
+     ]}.
+
+config_test_f(Conf, Pre) ->
+    fun() ->
+            restart_jobs_server(),
+            compare_configs(Pre, prune_info(jobs:info(all)), Conf)
+    end.
+
+rate_recovers(#{dynamic := [{queue,Q,[{standard_rate,R}]}]} = _Conf, _Pre) ->
+    fun() ->
+            true = test_rate(Q, R),
+            restart_jobs_server(),
+            true = test_rate(Q, R)
+    end.
+
+restart_jobs_server() ->
+    exit(whereis(jobs_server), kill),
+    await_jobs_server(1000).
+
+test_rate(Q, R) ->
+            T0 = erlang:system_time(millisecond),
+            Times = [jobs:run(Q, fun() ->
+                                          erlang:system_time(millisecond)
+                                  end) || _ <- lists:seq(1,10)],
+    TimeLimit = 1000 * 10 * (1/R), % in milliseconds
+    Actual = (lists:last(Times) - T0),
+    %% allow for 10% deviation
+    {true, _} = {Actual =< (TimeLimit * 1.1),
+                 {TimeLimit, Actual, T0, Times}},
+    true.
+
+
+start_server_w_config(Conf) ->
+    ensure_jobs_cleared(),
+    application:load(jobs),
+    set_env_w_config(Conf),
+    application:ensure_started(jobs),
+    post_start_config(Conf),
+    apply_dynamic(maps:get(dynamic, Conf, [])),
+    prune_info(jobs:info(all)).
+
+ensure_jobs_cleared() ->
+    application:stop(jobs),
+    application:unload(jobs).
+
+set_env_w_config(#{preset := Preset, restore := {Restore, Ctxt}}) ->
+    Queues = [{Q, [{standard_rate,2}]} || {queue, Q} <- Preset],
+    application:set_env(jobs, queues, Queues),
+    [application:set_env(jobs, auto_restore, Restore) || Ctxt == preset],
+    ok.
+
+post_start_config(#{restore := {Restore, dynamic}}) ->
+    jobs_server:auto_restore(Restore);
+post_start_config(_) ->
+    ok.
+
+apply_dynamic(Dyn) ->
+    lists:foreach(
+      fun({queue, Q}) ->
+              ok = jobs:add_queue(Q, [{standard_rate, 2}]);
+         ({queue, Q, Opts}) ->
+              ok = jobs:add_queue(Q, Opts)
+      end, Dyn).
+
+await_jobs_server(Timeout) ->
+    TRef = erlang:start_timer(Timeout, self(), await_jobs_server),
+    await_jobs_server_(TRef).
+
+await_jobs_server_(TRef) ->
+    case whereis(jobs_server) of
+        undefined ->
+            receive
+                {timeout, TRef, await_jobs_server} ->
+                    erlang:error(timeout)
+            after 10 ->
+                    await_jobs_server_(TRef)
+            end;
+        Pid when is_pid(Pid) ->
+            case is_process_alive(Pid) of
+                true ->
+                    erlang:cancel_timer(TRef),
+                    Pid;
+                false ->
+                    await_jobs_server_(TRef)
+            end
+    end.
+
+prune_info(Info) ->
+    lists:map(fun prune_info_/1, Info).
+
+prune_info_({queues, Qs}) ->
+    {queues, [{Q, prune_q_info(Iq)} || {Q, Iq} <- Qs]};
+prune_info_(I) ->
+    I.
+
+prune_q_info(I) ->
+    [X || {K,_} = X <- I,
+          not lists:member(K, [check_interval,
+                               latest_dispatch, approved, queued,
+                               oldest_job, timer, empty, depleted,
+                               waiters, stateful, st])].
+
+compare_configs(_, _, #{restore := {false,_}}) -> true;
+compare_configs(I1, I2, Conf) ->
+    {I1, I2, _} = {I2, I1, Conf}.
 
 serial(R, N, TargetRatio) ->
     Expected = (N div R) * 1000000 * TargetRatio,


### PR DESCRIPTION
(Note: this is in the unlikely event that the jobs_server crashes)

Added a few test cases verifying the basic functionality, including
that traffic on a queue can resume after process restart

Updated overview.edoc.

Also fixed a problem where the `queued` metric wasn't being updated