### PR TITLE
Uw link queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,30 @@ ok
 
 ```
 
+#### Demo - linked queues ####
+
+```erlang
+3> Pid = spawn(fun() -> receive stop -> ok end end).
+<0.131.0>
+4> jobs:add_queue(q, [{standard_rate,1}, {link, Pid}]).
+ok
+5> jobs:run(q, fun() -> io:fwrite("job: ~p~n", [time()]) end).
+job: {19,33,37}
+ok
+6> exit(Pid, kill).
+
+=INFO REPORT==== 29-May-2020::19:33:45 ===
+    jobs: removing_queue
+    name: q
+    reason: linked
+true
+7> jobs:run(q, fun() -> io:fwrite("job: ~p~n", [time()]) end).
+** exception error: bad argument
+     in function  jobs_server:call/3 (/home/uwiger/uw/jobs/src/jobs_server.erl, line 236)
+     in call from jobs_server:run/2 (/home/uwiger/uw/jobs/src/jobs_server.erl, line 117)
+8> jobs:queue_info(q).
+undefined
+```
 
 #### Demo - queue status ####
 
@@ -428,17 +452,16 @@ For issues, comments or feedback please [create an issue!] [1]
 
 
 <table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs.md" class="module">jobs</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_app.md" class="module">jobs_app</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_info.md" class="module">jobs_info</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_lib.md" class="module">jobs_lib</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_prod_simple.md" class="module">jobs_prod_simple</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_queue.md" class="module">jobs_queue</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_queue_list.md" class="module">jobs_queue_list</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_sampler.md" class="module">jobs_sampler</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_sampler_cpu.md" class="module">jobs_sampler_cpu</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_sampler_history.md" class="module">jobs_sampler_history</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_sampler_mnesia.md" class="module">jobs_sampler_mnesia</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_server.md" class="module">jobs_server</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/jobs/blob/master/doc/jobs_stateful_simple.md" class="module">jobs_stateful_simple</a></td></tr></table>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs.md" class="module">jobs</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_app.md" class="module">jobs_app</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_info.md" class="module">jobs_info</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_lib.md" class="module">jobs_lib</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_prod_simple.md" class="module">jobs_prod_simple</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_queue.md" class="module">jobs_queue</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_queue_list.md" class="module">jobs_queue_list</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_sampler.md" class="module">jobs_sampler</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_sampler_cpu.md" class="module">jobs_sampler_cpu</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_sampler_history.md" class="module">jobs_sampler_history</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_sampler_mnesia.md" class="module">jobs_sampler_mnesia</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/jobs/blob/uw-link-queue/doc/jobs_stateful_simple.md" class="module">jobs_stateful_simple</a></td></tr></table>
 

--- a/include/jobs.hrl
+++ b/include/jobs.hrl
@@ -166,6 +166,7 @@
         check_interval       :: q_check_interval() | undefined,
         oldest_job           :: integer() | undefined,
         timer,
+        link_ref = undefined :: undefined | reference(),
         check_counter = 0    :: integer(),
         empty = false        :: boolean(),
         depleted = false     :: boolean(),

--- a/src/jobs.erl
+++ b/src/jobs.erl
@@ -167,6 +167,14 @@ job_info({_, Opaque}) ->
 %% number of elements in the queue.
 %%  If `undefined', no limit is imposed.
 %%
+%% * `{link, undefined | pid()}', links the queue to a process. The queue
+%%   will automatically be removed if the process dies. Default is `undefined',
+%%   which means that the queue will not be linked. An exception will be raised
+%%   if the option value is anything other than `undefined' or a valid pid.
+%%   Note that if the referenced pid is not alive at queue creation time, the
+%%   queue will be removed directly afterwards. An info report will be issued
+%%   when the queue is removed.
+%%
 %% * `{mod, M}', indicates which queue behavior to use. Default is `jobs_queue'.
 %%
 %% In addition, some 'abbreviated' options are supported:


### PR DESCRIPTION
Inspired by a [tweet from Saša Jurić](https://twitter.com/sasajuric/status/1266378686468632576), I added a queue option, `{link, undefined | pid()}`. A linked queue is removed if the specified pid dies.