### PR TITLE
Adding error with reason to modify_queue/2 spec

### DIFF
--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -162,7 +162,7 @@ dequeue(Type, N) when N==infinity; is_integer(N), N > 0 ->
 add_queue(Name, Options) ->
     call(?SERVER, {add_queue, Name, Options}).
 
--spec modify_queue(queue_name(), q_opts()) -> ok.
+-spec modify_queue(queue_name(), q_opts()) -> ok | {error, any()}.
 %%
 modify_queue(Name, Options) ->
     call(?SERVER, {modify_queue, Name, Options}).


### PR DESCRIPTION
Hi @uwiger, the spec for jobs_server:modify_queue missed {error, Reason}. To avoid the dialyzer warning when other applications using jobs, we should add it. 

-spec modify_queue(queue_name(), q_opts()) -> ok | {error, any()}.